### PR TITLE
#20 First attempt to add STDOUT to Exception

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ if you are using maven add this snippet to your pom:
 <dependency>
     <groupId>org.buildobjects</groupId>
     <artifactId>jproc</artifactId>
-    <version>2.4.0</version>
+    <version>2.2.0</version>
 </dependency>
 ~~~
 
@@ -237,7 +237,7 @@ try {
 }
 ~~~
 
-Satus codes that are not expected will so still lead to an exception:
+Status codes that are not expected will so still lead to an exception:
 
 ~~~ .java
 try {

--- a/src/main/java/org/buildobjects/process/ExternalProcessFailureException.java
+++ b/src/main/java/org/buildobjects/process/ExternalProcessFailureException.java
@@ -1,5 +1,8 @@
 package org.buildobjects.process;
 
+import java.io.ByteArrayOutputStream;
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 /**
  * Signals the failure of an external process that returned a non zero exit code. It captures additional information
  * such as the output on stderr.
@@ -8,40 +11,68 @@ public class ExternalProcessFailureException extends RuntimeException {
     final private String command;
     final private int exitValue;
     final private String stderr;
+    private final ByteArrayOutputStream stdout;
     final private long time;
 
-    ExternalProcessFailureException(String command, int exitValue, String stderr, long time) {
+    ExternalProcessFailureException(String command, int exitValue, String stderr, ByteArrayOutputStream stdOut, long time) {
         this.command = command;
         this.exitValue = exitValue;
         this.stderr = stderr;
+        this.stdout = stdOut;
         this.time = time;
+    }
+
+    private String prefixLines(String string, String prefix) {
+        StringBuilder builder = new StringBuilder();
+        String[] lines = string.split("\n");
+        for (String line : lines) {
+            builder.append(prefix + line + "\n");
+        }
+        return builder.toString();
     }
 
     @Override
     public String getMessage() {
+        String formattedStdErr = stderr != null ? stderr : "Stderr unavailable as it has been consumed by user provided stream.";
+        String formattedStdOut = stdout != null ? new String(stdout.toByteArray(), UTF_8) : "";
+        if (!formattedStdErr.isEmpty() && !formattedStdOut.isEmpty()) {
+            formattedStdErr = prefixLines(formattedStdErr, "STDERR: ");
+            formattedStdOut = prefixLines(formattedStdOut, "STDOUT: ");
+        }
+
         return
             "External process '" + command +
-            "' returned " + exitValue +
-            " after " + time + "ms\n" +
-            (stderr != null ? stderr : "Stderr unavailable as it has been consumed by user provided stream.") ;
+                "' returned " + exitValue +
+                " after " + time + "ms\n" +
+                formattedStdErr +
+                formattedStdOut;
+
     }
 
-    /** @return the command that was executed */
+    /**
+     * @return the command that was executed
+     */
     public String getCommand() {
         return command;
     }
 
-    /** @return the actual exit value */
+    /**
+     * @return the actual exit value
+     */
     public int getExitValue() {
         return exitValue;
     }
 
-    /** @return the output on stderr */
+    /**
+     * @return the output on stderr
+     */
     public String getStderr() {
         return stderr;
     }
 
-    /** @return the execution time until the process failed*/    
+    /**
+     * @return the execution time until the process failed
+     */
     public long getTime() {
         return time;
     }

--- a/src/main/java/org/buildobjects/process/ProcBuilder.java
+++ b/src/main/java/org/buildobjects/process/ProcBuilder.java
@@ -204,11 +204,14 @@ public class ProcBuilder {
         try {
             Proc proc = new Proc(command, args, env, stdin, outputConsumer != null ? outputConsumer : stdout , directory, timoutMillis, stderr);
 
+            final ByteArrayOutputStream output = defaultStdout == stdout && outputConsumer == null ? defaultStdout : null;
+
             if (expectedExitStatuses.size() > 0 && !expectedExitStatuses.contains(proc.getExitValue())) {
-                throw new ExternalProcessFailureException(proc.toString(), proc.getExitValue(), proc.getErrorString(), proc.getExecutionTime());
+                throw new ExternalProcessFailureException(proc.toString(), proc.getExitValue(), proc.getErrorString(), output, proc.getExecutionTime());
             }
 
-            return new ProcResult(proc.toString(), defaultStdout == stdout && outputConsumer == null ? defaultStdout : null, proc.getExitValue(), proc.getExecutionTime(), proc.getErrorBytes());
+
+            return new ProcResult(proc.toString(), output, proc.getExitValue(), proc.getExecutionTime(), proc.getErrorBytes());
         } finally {
             stdout = defaultStdout = new ByteArrayOutputStream();
             stdin = null;


### PR DESCRIPTION
The current implementation relies on the assumption that relevant error output always goes to stderr. This is not true.
stdout also sometimes contains error messages (and context) that might help.