### PR TITLE
Use consumer to handle stderr the same way that consumer handles stdout.

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,32 @@ new ProcBuilder("echo")
     .run();
 ~~~
 
+Of course, you can consume stderr in the same way
+
+~~~ .java
+new ProcBuilder("bash")
+    .withArgs("-c", ">&2 echo error;>&2 echo error2;echo stdout")
+    .withOutputConsumer(new StreamConsumer() {
+        @Override
+        public void consume(InputStream stream) throws IOException {
+            BufferedReader reader = new BufferedReader(new InputStreamReader(stream));
+            assertEquals("stdout", reader.readLine());
+            assertNull(reader.readLine());
+        }
+    })
+    .withErrorConsumer(new StreamConsumer() {
+        @Override
+        public void consume(InputStream stream) throws IOException {
+            BufferedReader reader = new BufferedReader(new InputStreamReader(stream));
+            assertEquals("error", reader.readLine());
+            assertEquals("error2", reader.readLine());
+            assertNull(reader.readLine());
+        }
+    })
+    .withTimeoutMillis(2000)
+    .run();
+~~~
+
 Error output can also be accessed directly:
 
 ~~~ .java

--- a/src/main/java/org/buildobjects/process/ProcBuilder.java
+++ b/src/main/java/org/buildobjects/process/ProcBuilder.java
@@ -202,6 +202,10 @@ public class ProcBuilder {
             throw new IllegalArgumentException("You can either ...");
         }
 
+        if (stderr != null && errorConsumer != null) {
+            throw new IllegalArgumentException("You can either ...");
+        }
+
         try {
             Proc proc = new Proc(command, args, env, stdin, outputConsumer != null ? outputConsumer : stdout , directory, timoutMillis, errorConsumer != null ? errorConsumer : stderr);
 

--- a/src/main/java/org/buildobjects/process/ProcBuilder.java
+++ b/src/main/java/org/buildobjects/process/ProcBuilder.java
@@ -28,6 +28,7 @@ public class ProcBuilder {
     private File directory;
 
     private StreamConsumer outputConsumer;
+    private StreamConsumer errorConsumer;
 
 
     /** Creates a new ProcBuilder
@@ -202,7 +203,7 @@ public class ProcBuilder {
         }
 
         try {
-            Proc proc = new Proc(command, args, env, stdin, outputConsumer != null ? outputConsumer : stdout , directory, timoutMillis, stderr);
+            Proc proc = new Proc(command, args, env, stdin, outputConsumer != null ? outputConsumer : stdout , directory, timoutMillis, errorConsumer != null ? errorConsumer : stderr);
 
             final ByteArrayOutputStream output = defaultStdout == stdout && outputConsumer == null ? defaultStdout : null;
 
@@ -268,6 +269,16 @@ public class ProcBuilder {
     public ProcBuilder withOutputConsumer(StreamConsumer outputConsumer) {
         this.outputConsumer = outputConsumer;
 
+        return this;
+    }
+
+    /**
+     * Process the error output with given consumer object
+     * @param errorConsumer an object that defines how to process the error output stream
+     * @return this, for chaining
+     */
+    public ProcBuilder withErrorConsumer(StreamConsumer errorConsumer) {
+        this.errorConsumer = errorConsumer;
         return this;
     }
 

--- a/src/test/java/org/buildobjects/process/ProcBuilderTest.java
+++ b/src/test/java/org/buildobjects/process/ProcBuilderTest.java
@@ -406,6 +406,34 @@ public class ProcBuilderTest {
     }
 
     /**
+     * Use consumer handling both stdout and stderr.
+     */
+    @Test
+    public void testErrorConsumer() {
+        new ProcBuilder("bash")
+            .withArgs("-c", ">&2 echo error;>&2 echo error2;echo stdout")
+            .withOutputConsumer(new StreamConsumer() {
+                @Override
+                public void consume(InputStream stream) throws IOException {
+                    BufferedReader reader = new BufferedReader(new InputStreamReader(stream));
+                    assertEquals("stdout", reader.readLine());
+                    assertNull(reader.readLine());
+                }
+            })
+            .withErrorConsumer(new StreamConsumer() {
+                @Override
+                public void consume(InputStream stream) throws IOException {
+                    BufferedReader reader = new BufferedReader(new InputStreamReader(stream));
+                    assertEquals("error", reader.readLine());
+                    assertEquals("error2", reader.readLine());
+                    assertNull(reader.readLine());
+                }
+            })
+            .withTimeoutMillis(2000)
+            .run();
+    }
+
+    /**
      * [NO-DOC]
      */
     @Test


### PR DESCRIPTION
Origin Proc constructor allow stderr as Object instance of Consumer.
But ProcBuilder handle stderr only with stream.
New `errorConsumer` and `withErrorConsumer` is provided, along with modification in `run()`. Document and test are added, too.

Signed-off-by: tomriddly <tomriddly@qq.com>