### PR TITLE
Add jacoco plugin and make javadoc plugin work with system property

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,29 @@
                         </goals>
                     </execution>
                 </executions>
+                <configuration>
+                    <javadocExecutable>${java.home}/bin/javadoc</javadocExecutable>
+                </configuration>
+            </plugin>
+            <!-- Code Coverage report generation -->
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.7</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>generate-code-coverage-report</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
1. Added Jacoco plugin to get code coverage
2. Configured the maven-javadoc-plugin to read the java.home system property as it was not working with Java 11. 

@fleipold Thank you for creating this. I had written my own version of this for work and while searching found this repo. This is much better than what I wrote. 👍 

 Let me know if you want me to remove/update any of these properties. 