### PR TITLE
Add method to add multiple variables to the process's environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,22 @@ ProcResult result = new ProcBuilder("bash")
     .withVar("MYVAR", "my value").run();
 
 assertEquals("my value\n", result.getOutputString());
-assertEquals("bash -c 'echo $MYVAR'", result.getProcString());
+assertEquals("bash -c 'echo $MYVAR'", result.getCommandLine());
+~~~
+
+If you want to set multiple environment variables, you can pass a Map.
+
+~~~ .java
+Map<String, String> envVariables = new HashMap<>();
+envVariables.put("var1", "val 1");
+envVariables.put("var2", "val 2");
+ProcResult result = new ProcBuilder("bash")
+        .withArgs("-c", "env")
+        .withVars(envVariables).run();
+
+assertTrue(result.getOutputString().contains("var1=val 1\n"));
+assertTrue(result.getOutputString().contains("var2=val 2\n"));
+assertEquals("bash -c env", result.getCommandLine());
 ~~~
 
 By default the new program is spawned in the working directory of

--- a/src/main/java/org/buildobjects/process/ProcBuilder.java
+++ b/src/main/java/org/buildobjects/process/ProcBuilder.java
@@ -15,7 +15,7 @@ public class ProcBuilder {
 
     private String command;
     private List<String> args = new ArrayList<String>();
-    private Map<String, String> env = new HashMap<String, String>();
+    private Map<String, String> env = new HashMap<>();
 
     private OutputStream stdout = defaultStdout;
     private InputStream stdin;
@@ -267,12 +267,27 @@ public class ProcBuilder {
         return builder.run().getOutputString();
     }
 
-    /** Add a variable to the processes environment
+    /**
+     * Add a variable to the processes environment
+     *
      * @param var variable name
      * @param value the value to be passed in
-     * @return this, for chaining*/
+     * @return this, for chaining
+     * */
     public ProcBuilder withVar(String var, String value) {
         env.put(var, value);
+        return this;
+    }
+
+    /**
+     * Add multiple variables to the process's environment
+     *
+     * @param vars Map of variable and it's value
+     * @return this, for chaining
+     */
+
+    public ProcBuilder withVars(Map<String, String> vars){
+        env.putAll(vars);
         return this;
     }
 

--- a/src/test/java/org/buildobjects/process/ProcBuilderTest.java
+++ b/src/test/java/org/buildobjects/process/ProcBuilderTest.java
@@ -3,6 +3,8 @@ package org.buildobjects.process;
 import org.junit.Test;
 
 import java.io.*;
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.junit.Assert.*;
 
@@ -145,8 +147,23 @@ public class ProcBuilderTest {
             .withVar("MYVAR", "my value").run();
 
         assertEquals("my value\n", result.getOutputString());
-        assertEquals("bash -c 'echo $MYVAR'", result.getProcString());
+        assertEquals("bash -c 'echo $MYVAR'", result.getCommandLine());
     }
+
+    @Test
+    public void testPassingInMultipleVariables() {
+        Map<String, String> envVariables = new HashMap<>();
+        envVariables.put("var1", "val 1");
+        envVariables.put("var2", "val 2");
+        ProcResult result = new ProcBuilder("bash")
+                .withArgs("-c", "env")
+                .withVars(envVariables).run();
+
+        assertTrue(result.getOutputString().contains("var1=val 1\n"));
+        assertTrue(result.getOutputString().contains("var2=val 2\n"));
+        assertEquals("bash -c env", result.getCommandLine());
+    }
+
 
     /**
      * By default the new program is spawned in the working directory of


### PR DESCRIPTION
1. The user can now pass a Map of environment variables using method `withVars`
2. Added the test
3. Update README