### PR TITLE
Fix the shell script to update the version in the Test file

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -60,6 +60,7 @@ vim /tmp/release-notes-candidate.txt
 release_notes=$(cat /tmp/release-notes-candidate.txt)
 
 sed -i "" -E "s%(.*)<version>[^<]*</version>%\1<version>${version}</version>%g" README.md
+sed -i "" -E "s%(.*)<version>[^<]*</version>%\1<version>2.9.2</version>%g" src/test/java/org/buildobjects/process/ProcBuilderTest.java
 
 git branch --force "release-${tag}"
 git checkout "release-${tag}"


### PR DESCRIPTION
The README is generated through ProcBuilderTest.java. So, even though there is no change in the code,
with every build, when the README was getting generated, was showing up as modified. This commit fixes that.