### PR TITLE
Fix #36; Avoid uncaught exception on timeout

### DIFF
--- a/src/main/java/org/buildobjects/process/ByteArrayConsumptionThread.java
+++ b/src/main/java/org/buildobjects/process/ByteArrayConsumptionThread.java
@@ -32,8 +32,10 @@ class ByteArrayConsumptionThread implements OutputConsumptionThread {
                 try {
                     bytes = toByteArray(inputStream);
                 } catch (Throwable t) {
-                    ByteArrayConsumptionThread.this.throwable = t;
-                    eventSink.dispatch(EXCEPTION_IN_STREAM_HANDLING);
+                    if (!thread.isInterrupted()) {
+                        ByteArrayConsumptionThread.this.throwable = t;
+                        eventSink.dispatch(EXCEPTION_IN_STREAM_HANDLING);
+                    }
                 }
             }
         });

--- a/src/main/java/org/buildobjects/process/StreamConsumerConsumptionThread.java
+++ b/src/main/java/org/buildobjects/process/StreamConsumerConsumptionThread.java
@@ -28,8 +28,10 @@ class StreamConsumerConsumptionThread implements OutputConsumptionThread {
                     stdout.consume(inputStream);
 
                 } catch (Throwable t) {
-                    StreamConsumerConsumptionThread.this.throwable = t;
-                    eventSink.dispatch(EXCEPTION_IN_STREAM_HANDLING);
+                    if (!thread.isInterrupted()) {
+                        StreamConsumerConsumptionThread.this.throwable = t;
+                        eventSink.dispatch(EXCEPTION_IN_STREAM_HANDLING);
+                    }
                 }
             }
         });

--- a/src/main/java/org/buildobjects/process/StreamCopyConsumptionThread.java
+++ b/src/main/java/org/buildobjects/process/StreamCopyConsumptionThread.java
@@ -25,11 +25,14 @@ class StreamCopyConsumptionThread implements OutputConsumptionThread {
             public void run() {
                 try {
                     new StreamCopyRunner(inputStream, stdout, false).run();
-            } catch (Throwable t) {
-                StreamCopyConsumptionThread.this.throwable = t;
-                eventSink.dispatch(EXCEPTION_IN_STREAM_HANDLING);
+                } catch (Throwable t) {
+                    if (!thread.isInterrupted()) {
+                        StreamCopyConsumptionThread.this.throwable = t;
+                        eventSink.dispatch(EXCEPTION_IN_STREAM_HANDLING);
+                    }
+                }
             }
-        }});
+        });
         this.thread.start();
     }
 


### PR DESCRIPTION
This pull request addresses issue #36 "Uncaught exception print in stderr when timeout".

It avoids dispatch events when the thread is interrupted.

